### PR TITLE
Move webpack to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
     "es6-shim": "^0.33.3",
     "redux": "^3.2.1",
     "ts-loader": "^0.8.0",
-    "webpack": "^1.12.12"
   },
   "devDependencies": {
     "mocha": "^2.4.5",
     "must": "^0.13.1",
     "sinon": "^1.17.3",
     "typescript": "^1.7.5",
+    "webpack": "^1.12.12",
     "yargs": "^3.32.0"
   },
   "description": "A ridiculously good syntax for working with Redux and TypeScript.  Currently limited to Angular 2 but could potentially be used elsewhere.",

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
   "license": "MIT",
   "dependencies": {
     "es6-shim": "^0.33.3",
-    "redux": "^3.2.1",
-    "ts-loader": "^0.8.0",
+    "redux": "^3.2.1"
   },
   "devDependencies": {
     "mocha": "^2.4.5",
     "must": "^0.13.1",
     "sinon": "^1.17.3",
     "typescript": "^1.7.5",
+    "ts-loader": "^0.8.0",
     "webpack": "^1.12.12",
     "yargs": "^3.32.0"
   },


### PR DESCRIPTION
@KarlPurk I think `webpack` shouldn't be a dependency. I use JSPM / SystemJS to build my application. 

It can be in `devDependencies`.